### PR TITLE
feat: add GitHub Actions workflow for automatic versioning and publis…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,88 @@
+# Opción 1: Auto-increment version en cada push a main
+name: Auto Version and Publish
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    types: [closed]
+
+jobs:
+  version-and-publish:
+    # Solo ejecutar en push a main o cuando se hace merge de PR
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # Necesario para poder hacer commits
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      # Determinar tipo de version bump basado en el commit
+      - name: Determine version bump
+        id: version_bump
+        run: |
+          # Obtener el último commit message
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+
+          if [[ $COMMIT_MSG == *"BREAKING CHANGE"* ]] || [[ $COMMIT_MSG == *"major:"* ]]; then
+            echo "bump=major" >> $GITHUB_OUTPUT
+          elif [[ $COMMIT_MSG == *"feat:"* ]] || [[ $COMMIT_MSG == *"feature:"* ]]; then
+            echo "bump=minor" >> $GITHUB_OUTPUT
+          else
+            echo "bump=patch" >> $GITHUB_OUTPUT
+          fi
+
+      # Incrementar versión
+      - name: Bump version
+        run: |
+          npm version ${{ steps.version_bump.outputs.bump }} --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Build project
+        run: npm run build
+
+      # Commit y push de la nueva versión
+      - name: Commit version bump
+        run: |
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to v${{ env.NEW_VERSION }} [skip ci]"
+          git tag "v${{ env.NEW_VERSION }}"
+          git push origin main
+          git push origin "v${{ env.NEW_VERSION }}"
+
+      # Publicar en NPM
+      - name: Publish to NPM
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Notificación de éxito
+      - name: Success notification
+        run: |
+          echo "✅ Package published successfully!"
+          echo "📦 Package: $(npm list --depth=0 | head -1)"
+          echo "🔗 NPM: https://www.npmjs.com/package/$(node -p "require('./package.json').name")"


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate versioning and publishing of the package to NPM. The workflow increments the version based on commit messages, builds the project, publishes it to NPM, and tags the release in the repository.

### New GitHub Actions Workflow:
* Added `.github/workflows/publish.yml` to automate versioning and publishing:
  - Triggers on pushes to the `main` branch or when pull requests are merged into `main`.
  - Determines the version bump type (`major`, `minor`, or `patch`) based on commit messages.
  - Increments the version, builds the project, commits the updated version, tags it, and pushes the changes.
  - Publishes the package to NPM using the `NODE_AUTH_TOKEN` secret.
  - Includes a success notification step to confirm the package was published.…hing