### PR TITLE
fix: update Node.js version to 22.15.0 and change build command to us…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22.15.0'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
@@ -36,9 +36,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Run tests
-        run: npm test
 
       # Determinar tipo de version bump basado en el commit
       - name: Determine version bump
@@ -63,7 +60,7 @@ jobs:
           echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
 
       - name: Build project
-        run: npm run build
+        run: npm run build:tsup
 
       # Commit y push de la nueva versión
       - name: Commit version bump


### PR DESCRIPTION
This pull request updates the Node.js version, modifies the build process, and removes unnecessary steps in the GitHub Actions workflow for publishing.

### Updates to Node.js version:
* Updated the Node.js version from `18` to `22.15.0` in the `Setup Node.js` step of the `.github/workflows/publish.yml` file.

### Workflow simplifications:
* Removed the `Run tests` step from the workflow, streamlining the process.

### Build process changes:
* Changed the build command from `npm run build` to `npm run build:tsup` in the `Build project` step, likely to align with a new build tool or process.…e tsup