### PR TITLE
fix: update Git configuration to use secrets for email and username

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
+          git config --local user.email ${{ secrets.GITHUB_EMAIL }}
+          git config --local user.name "Breimerct"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This pull request updates the Git configuration in the `publish.yml` workflow file to use a secret for the email and a specific username.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L34-R35): Replaced the hardcoded Git email and username with `${{ secrets.GITHUB_EMAIL }}` and `"Breimerct"`, respectively, to improve security and identify the user more clearly.