### PR TITLE
fix: update GitHub token and email secrets in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # Necesario para poder hacer commits
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
 
       - name: Setup Node.js
@@ -31,7 +31,7 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --local user.email ${{ secrets.GITHUB_EMAIL }}
+          git config --local user.email ${{ secrets.GH_EMAIL }}
           git config --local user.name "Breimerct"
 
       - name: Install dependencies


### PR DESCRIPTION
This pull request updates the `.github/workflows/publish.yml` file to replace deprecated secrets with new ones for authentication and configuration purposes.

Authentication updates:

* Changed the token used for commits from `${{ secrets.GITHUB_TOKEN }}` to `${{ secrets.GH_TOKEN }}` to align with updated secret naming conventions. (`[.github/workflows/publish.ymlL22-R22](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L22-R22)`)

Configuration updates:

* Updated the Git user email configuration from `${{ secrets.GITHUB_EMAIL }}` to `${{ secrets.GH_EMAIL }}` for consistency with the new secret naming. (`[.github/workflows/publish.ymlL34-R34](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L34-R34)`)