### PR TITLE
fix: update import paths to use relative paths in app, http-client

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,5 +1,5 @@
-import { HttpClient } from '@/client';
-import { HttpClientConfig, HttpResponse, RequestConfig } from '@/types';
+import { HttpClient } from '../client';
+import { HttpClientConfig, HttpResponse, RequestConfig } from '../types';
 
 const defaultHttpClient = new HttpClient();
 

--- a/src/client/http-client.ts
+++ b/src/client/http-client.ts
@@ -5,7 +5,7 @@ import {
   createHttpError,
   createTimeoutSignal,
   getFetch,
-} from '@/helpers';
+} from '../helpers';
 import {
   QueryParams,
   HttpHeaders,
@@ -15,7 +15,7 @@ import {
   RequestConfig,
   HttpClientConfig,
   Interceptors,
-} from '@/types';
+} from '../types';
 
 export class HttpClient {
   private config: HttpClientConfig;

--- a/src/helpers/utils.ts
+++ b/src/helpers/utils.ts
@@ -1,5 +1,5 @@
-import { HttpCode } from '@/constants';
-import { HttpError, HttpHeaders, QueryParams } from '@/types';
+import { HttpCode } from '../constants';
+import { HttpError, HttpHeaders, QueryParams } from '../types';
 
 export function buildURL(baseURL: string = '', endpoint: string, params?: QueryParams): string {
   const cleanBaseURL = baseURL.replace(/\/$/, '');


### PR DESCRIPTION
This pull request updates import paths across several files to use relative paths instead of alias-based paths. This change ensures consistency in import statements and improves compatibility with certain build tools or environments that may not support alias-based imports.

### Updates to import paths:

* [`src/app/app.ts`](diffhunk://#diff-18f0b78b713daf3f4fc2d305926785508575bdc7f304363a64a3b3a2985b58beL1-R2): Changed imports for `HttpClient` and related types from alias-based paths (`@/client`, `@/types`) to relative paths (`../client`, `../types`).

* [`src/client/http-client.ts`](diffhunk://#diff-888759a6a81909394a723befb24ecb302554813fc88fd170f09496c1c9fbc38dL8-R8): Updated imports for helpers and types from alias-based paths (`@/helpers`, `@/types`) to relative paths (`../helpers`, `../types`). [[1]](diffhunk://#diff-888759a6a81909394a723befb24ecb302554813fc88fd170f09496c1c9fbc38dL8-R8) [[2]](diffhunk://#diff-888759a6a81909394a723befb24ecb302554813fc88fd170f09496c1c9fbc38dL18-R18)

* [`src/helpers/utils.ts`](diffhunk://#diff-94e01b9bcaf37dddbea5defec6f62b685b2f2362d74b42d01d29fab89a70432bL1-R2): Adjusted imports for constants and types from alias-based paths (`@/constants`, `@/types`) to relative paths (`../constants`, `../types`).…nd utils modules